### PR TITLE
Fixed missing reference error in GameManager-class

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -4,15 +4,5 @@ using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-	private GameCore gameCore;
-
-	private void Awake()
-	{
-		gameCore = new GameCore();
-	}
-
-	private void Start()
-	{
-		
-	}
+	// TODO: Implement in a later issue
 }


### PR DESCRIPTION
Does what title states by removing all references to 'GameCore' entirely.